### PR TITLE
Add function to take vessel to Mun orbit

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,4 +1,5 @@
 import math
+import time
 
 
 def get_thrust_to_weight_ratio(conn, vessel):
@@ -208,6 +209,7 @@ def wait_for_time_to_periapsis_less_than(connection, vessel, target_time):
     with time_to_periapsis_event.condition:
         time_to_periapsis_event.wait()
 
+
 def wait_for_time_to_manuever_less_than(connection, vessel, node, target_time):
     """
     Wait the manuever node to be less that a given value in seconds.
@@ -215,6 +217,7 @@ def wait_for_time_to_manuever_less_than(connection, vessel, node, target_time):
     :params vessel: A vessel object
     :params target_time: A double of the time to maneuver node in seconds
     """
+    print(f"Waiting for maneuver node: {int(node.time_to)} seconds")
     time_to_manuever = connection.get_call(getattr, node, "time_to")
     monitor_time_to_manuever_expression = connection.krpc.Expression.less_than(
         connection.krpc.Expression.call(time_to_manuever),
@@ -222,6 +225,25 @@ def wait_for_time_to_manuever_less_than(connection, vessel, node, target_time):
     )
     time_to_manuever_event = connection.krpc.add_event(
         monitor_time_to_manuever_expression
+    )
+    with time_to_manuever_event.condition:
+        time_to_manuever_event.wait()
+
+
+def wait_for_sphere_of_influence_change_less_than(connection, vessel, target_time):
+    """
+    Wait the sphere of influence change to be less that a given value in seconds.
+    :params conn: A krpc connection
+    :params vessel: A vessel object
+    :params target_time: A double of the time to maneuver node in seconds
+    """
+    time_to_manuever = connection.get_call(getattr, vessel.orbit, "time_to_soi_change")
+    monitor_time_to_sphere_of_influence_change = connection.krpc.Expression.less_than(
+        connection.krpc.Expression.call(time_to_manuever),
+        connection.krpc.Expression.constant_double(target_time),
+    )
+    time_to_manuever_event = connection.krpc.add_event(
+        monitor_time_to_sphere_of_influence_change
     )
     with time_to_manuever_event.condition:
         time_to_manuever_event.wait()
@@ -237,33 +259,68 @@ def get_relative_inclination_degrees(vessel, target_orbit):
     return math.degrees(relative_inclination)
 
 
-def even_orbit(connection, vessel):
+def even_orbit(connection, vessel, node, next_orbit=False):
+    """
+    Wait the sphere of influence change to be less that a given value in seconds.
+    :params conn: A krpc connection
+    :params vessel: A vessel object
+    :params target_time: A double of the time to maneuver node in seconds
+    :params node: An existing node object
+    :params next_orbit: Whether to use the current orbit or the next orbit, if
+    the sphere of influence is expected to change.
+    """
+    if next_orbit:
+        orbit = vessel.orbit.next_orbit
+    else:
+        orbit = vessel.orbit
     # Use manuever nodes to even out the orbit
-    apoapsis_time = connection.space_center.ut + vessel.orbit.time_to_apoapsis
-    periapsis_time = connection.space_center.ut + vessel.orbit.time_to_periapsis
+    apoapsis_time = connection.space_center.ut + orbit.time_to_apoapsis
+    periapsis_time = connection.space_center.ut + orbit.time_to_periapsis
     print(f"Apoapsis time: {apoapsis_time} | Periapsis time: {periapsis_time}")
     if apoapsis_time < periapsis_time:
-        print("Closer to periapsis")
-        closer_to_periapsis = True
-    else:
         print("Closer to apoapsis")
-        closer_to_periapsis = False
+        node_time = apoapsis_time
+    else:
+        print("Closer to periapsis")
+        node_time = periapsis_time
     # Create a manuever node at the apoapsis
-    node = vessel.control.add_node(
-        apoapsis_time,
-    )
-    delta_v_increment_by = 25
+    node.ut = node_time
+    delta_v_increment_by = 10
     minimum_difference = 1000
-    while vessel.orbit.apoapsis - node.orbit.periapsis > minimum_difference:
-        node.prograde += delta_v_increment_by
+    if node_time == apoapsis_time:
+        while (
+            abs(node.orbit.apoapsis_altitude - node.orbit.periapsis_altitude)
+            > minimum_difference
+        ):
+            node.prograde += delta_v_increment_by
+            if math.isclose(
+                node.orbit.apoapsis_altitude, node.orbit.periapsis_altitude, rel_tol=0.1
+            ):
+                break
+
+    else:
+        while abs(node.orbit.periapsis - node.orbit.apoapsis) > minimum_difference:
+            node.prograde -= delta_v_increment_by
+            if math.isclose(node.orbit.apoapsis, node.orbit.periapsis, rel_tol=0.1):
+                break
+    print(
+        f"Apoapsis_altitude: {node.orbit.apoapsis_altitude} | Periapsis_altitude: {node.orbit.periapsis_altitude}"
+    )
+    print(
+        f"is_close: {math.isclose(node.orbit.apoapsis_altitude, node.orbit.periapsis_altitude, rel_tol=0.1)}"
+    )
+    print(
+        f"Difference: {abs(node.orbit.periapsis_altitude - node.orbit.apoapsis_altitude)}"
+    )
+    print("---")
     vessel.control.rcs = True
     vessel.auto_pilot.sas = True
     vessel.auto_pilot.sas_mode = vessel.auto_pilot.sas_mode.maneuver
-    wait_for_time_to_manuever_less_than(connection, vessel, node, 20)
-    while node.remaining_delta_v > 50:
-        vessel.control.throttle = 1
+    wait_for_time_to_manuever_less_than(connection, vessel, node, 30)
     while node.remaining_delta_v > 5:
-        vessel.control.throttle = 0.3
+        vessel.control.throttle = 1
     vessel.control.throttle = 0
     vessel.control.rcs = False
     vessel.auto_pilot.sas = False
+    print("Removing node")
+    node.remove()

--- a/helpers.py
+++ b/helpers.py
@@ -188,3 +188,50 @@ def wait_for_time_to_apoapsis_less_than(connection, vessel, target_time):
     )
     with time_to_apoapsis_event.condition:
         time_to_apoapsis_event.wait()
+
+
+def wait_for_time_to_periapsis_less_than(connection, vessel, target_time):
+    """
+    Wait for the time to periapsis to be less than a given value in seconds.
+    :params conn: A krpc connection
+    :params vessel: A vessel object
+    :params target_time: A double of the target time in seconds to the periapsis
+    """
+    time_to_periapsis = connection.get_call(getattr, vessel.orbit, "time_to_periapsis")
+    monitor_time_to_periapsis_expression = connection.krpc.Expression.less_than(
+        connection.krpc.Expression.call(time_to_periapsis),
+        connection.krpc.Expression.constant_double(target_time),
+    )
+    time_to_periapsis_event = connection.krpc.add_event(
+        monitor_time_to_periapsis_expression
+    )
+    with time_to_periapsis_event.condition:
+        time_to_periapsis_event.wait()
+
+def wait_for_time_to_manuever_less_than(connection, vessel, node, target_time):
+    """
+    Wait the manuever node to be less that a given value in seconds.
+    :params conn: A krpc connection
+    :params vessel: A vessel object
+    :params target_time: A double of the time to maneuver node in seconds
+    """
+    time_to_manuever = connection.get_call(getattr, node, "time_to")
+    monitor_time_to_manuever_expression = connection.krpc.Expression.less_than(
+        connection.krpc.Expression.call(time_to_manuever),
+        connection.krpc.Expression.constant_double(target_time),
+    )
+    time_to_manuever_event = connection.krpc.add_event(
+        monitor_time_to_manuever_expression
+    )
+    with time_to_manuever_event.condition:
+        time_to_manuever_event.wait()
+
+
+def get_relative_inclination_degrees(vessel, target_orbit):
+    """
+    Relative inclination of this orbit and the target orbit, in degrees.
+    params: Target orbit
+    Returns: The relative inclination in degrees as a double
+    """
+    relative_inclination = vessel.orbit.relative_inclination(target_orbit)
+    return math.degrees(relative_inclination)

--- a/mun.py
+++ b/mun.py
@@ -74,7 +74,7 @@ def orbit(connection, vessel, target_orbit_altitude):
     vessel.auto_pilot.sas = True
     vessel.auto_pilot.sas_mode = vessel.auto_pilot.sas_mode.retrograde
 
-    helpers.wait_for_time_to_periapsis_less_than(connection, vessel, 45)
+    helpers.wait_for_time_to_periapsis_less_than(connection, vessel, 30)
     print("Retro-burning...")
     vessel.control.throttle = 0.3
     # The apoapsis is initially reported as a minus number - probably because
@@ -91,7 +91,7 @@ def orbit(connection, vessel, target_orbit_altitude):
 
     # Even out the other side of the orbit
     print("Waiting for new periapsis to even out the orbit")
-    helpers.wait_for_time_to_periapsis_less_than(connection, vessel, 30)
+    helpers.wait_for_time_to_periapsis_less_than(connection, vessel, 60)
     print("Preparing for burn to even out the orbit")
     vessel.control.rcs = True
     vessel.auto_pilot.sas = True
@@ -101,7 +101,7 @@ def orbit(connection, vessel, target_orbit_altitude):
     else:
         vessel.auto_pilot.sas_mode = vessel.auto_pilot.sas_mode.prograde
 
-    helpers.wait_for_time_to_periapsis_less_than(connection, vessel, 3)
+    helpers.wait_for_time_to_periapsis_less_than(connection, vessel, 30)
     print("Burning...")
     if vessel.orbit.apoapsis_altitude > target_orbit_altitude:
         while vessel.orbit.apoapsis_altitude > target_orbit_altitude:

--- a/mun.py
+++ b/mun.py
@@ -1,0 +1,130 @@
+import krpc
+import helpers
+import orbit
+import time
+import sys
+from datetime import datetime
+
+
+def orbit(connection, vessel, target_orbit_altitude):
+    """
+    Takes a given vessel currently in orbit with Kerbin and moves to orbit with
+    the Mun.
+    :params connection: A krpc connection
+    :params vessel: A vessel object
+    :parmas target_orbit_altitude: A double of the target orbit altitude
+    """
+    start_time = datetime.now()
+    # Target the Mun - this will need to be set manually for now
+    mun_target = connection.space_center.target_body
+    if mun_target is None:
+        print(
+            "No target selected - make sure to select the Mun as a target before running this script"
+        )
+        sys.exit(1)
+
+    # Find out if we're closer to the ascending node or the descending node
+    ascending_node_time = vessel.orbit.ut_at_true_anomaly(
+        vessel.orbit.true_anomaly_at_an(mun_target.orbit)
+    )
+    descending_node_time = vessel.orbit.ut_at_true_anomaly(
+        vessel.orbit.true_anomaly_at_dn(mun_target.orbit)
+    )
+    if ascending_node_time < descending_node_time:
+        node_ut_time = ascending_node_time
+    else:
+        node_ut_time = descending_node_time
+    estimated_mun_encounter_delta_v = 860
+
+    # Create the manuever node
+    # TODO: This only creates manuever nodes on either the ascending or descending
+    # node, regardless of where the Mun is.  We should adjust where the node
+    # is placed dependng on the position of the Mun.
+    node = vessel.control.add_node(
+        node_ut_time, prograde=estimated_mun_encounter_delta_v
+    )
+
+    # Wait until we're close to the manuever node
+    print(f"Waiting for manuever ({int(node.time_to)} seconds)")
+    helpers.wait_for_time_to_manuever_less_than(connection, vessel, node, 20)
+    # Face the direction of the manuever node
+    print("Preparing for manuever")
+    vessel.auto_pilot.sas = True
+    vessel.control.rcs = True
+    vessel.auto_pilot.sas_mode = vessel.auto_pilot.sas_mode.maneuver
+
+    # Start burning in the direction of the manuever node
+    helpers.wait_for_time_to_manuever_less_than(connection, vessel, node, 3)
+    print("Burning...")
+    while node.remaining_delta_v > 5:
+        vessel.control.throttle = 1
+    # Finished burn
+    print("Manuever complete")
+    vessel.control.throttle = 0
+    vessel.control.rcs = False
+    vessel.auto_pilot.sas = False
+
+    # Wait until we're at the new orbit's periapsis, which should be at the Mun
+    print(
+        f"Waiting to arrive at {mun_target.name}'s periapsis ({int(vessel.orbit.time_to_periapsis)} seconds)"
+    )
+    helpers.wait_for_time_to_periapsis_less_than(connection, vessel, 60)
+    print("Preparing for retro-burn")
+    vessel.control.rcs = True
+    vessel.auto_pilot.sas = True
+    vessel.auto_pilot.sas_mode = vessel.auto_pilot.sas_mode.retrograde
+
+    helpers.wait_for_time_to_periapsis_less_than(connection, vessel, 45)
+    print("Retro-burning...")
+    vessel.control.throttle = 0.3
+    # The apoapsis is initially reported as a minus number - probably because
+    # we're still actually in orbit with Kerbin.  Keep boosting until the
+    # apoapsis begings reporting as a positive number.
+    helpers.wait_for_apoapsis_more_than(connection, vessel, 0)
+    # Keep boosting until the periapsis reaches the target altitude
+    while vessel.orbit.periapsis_altitude > target_orbit_altitude:
+        vessel.control.throttle = 0.1
+    print(f"At target apoapsis: {vessel.orbit.apoapsis_altitude}")
+    vessel.control.rcs = False
+    vessel.auto_pilot.sas = False
+    vessel.control.throttle = 0
+
+    # Even out the other side of the orbit
+    print("Waiting for new periapsis to even out the orbit")
+    helpers.wait_for_time_to_periapsis_less_than(connection, vessel, 30)
+    print("Preparing for burn to even out the orbit")
+    vessel.control.rcs = True
+    vessel.auto_pilot.sas = True
+
+    if vessel.orbit.apoapsis_altitude > target_orbit_altitude:
+        vessel.auto_pilot.sas_mode = vessel.auto_pilot.sas_mode.retrograde
+    else:
+        vessel.auto_pilot.sas_mode = vessel.auto_pilot.sas_mode.prograde
+
+    helpers.wait_for_time_to_periapsis_less_than(connection, vessel, 3)
+    print("Burning...")
+    if vessel.orbit.apoapsis_altitude > target_orbit_altitude:
+        while vessel.orbit.apoapsis_altitude > target_orbit_altitude:
+            vessel.control.throttle = 0.1
+    else:
+        while vessel.orbit.apoapsis_altitude < target_orbit_altitude:
+            vessel.control.throttle = 0.1
+
+    # In stable orbit
+    vessel.control.rcs = False
+    vessel.auto_pilot.sas = False
+    vessel.control.throttle = 0
+    vessel.auto_pilot.disengage()
+
+    duration = datetime.now() - start_time
+    print(f"{mun_target.name} orbit achieved in {duration}")
+    print(
+        f"Delta-v left: {helpers.get_estimated_delta_v(connection, vessel, sea_level_impulse=False)}"
+    )
+
+
+if __name__ == "__main__":
+    server_ip_address = "192.168.0.15"
+    connection = krpc.connect(address=server_ip_address)
+    vessel = connection.space_center.active_vessel
+    orbit(connection, vessel, 300000)

--- a/orbit.py
+++ b/orbit.py
@@ -37,13 +37,13 @@ def launch(connection, vessel, heading, target_altitude):
     print(f"Delta-v: {helpers.get_estimated_delta_v(connection, vessel)}")
 
     # Countdown...
-    print('3...')
+    print("3...")
     time.sleep(1)
-    print('2...')
+    print("2...")
     time.sleep(1)
-    print('1...')
+    print("1...")
     time.sleep(1)
-    print('Launch!')
+    print("Launch!")
     vessel.control.activate_next_stage()
 
     # Reduce thrusters and set pitch for orbit
@@ -63,14 +63,20 @@ def launch(connection, vessel, heading, target_altitude):
     vessel.auto_pilot.disengage()
     time.sleep(1)
 
-    helpers.even_orbit(connection, vessel)
+    # There appears to be an issue when creating a multiple maneuver nodes and
+    # monitoring its time_to attributes. For now, we create an empty maneuver
+    # node and pass that into the helpers.even_orbit function.
+    kerbin_node = vessel.control.add_node(connection.space_center.ut)
+    helpers.even_orbit(connection, vessel, kerbin_node)
 
     # In stable orbit
     vessel.control.rcs = False
     vessel.auto_pilot.disengage()
     launch_duration = datetime.now() - start_time
     print(f"Stable orbit achieved in {launch_duration}")
-    print(f"Delta-v left: {helpers.get_estimated_delta_v(connection, vessel, sea_level_impulse=False)}")
+    print(
+        f"Delta-v left: {helpers.get_estimated_delta_v(connection, vessel, sea_level_impulse=False)}"
+    )
 
 
 if __name__ == "__main__":

--- a/orbit.py
+++ b/orbit.py
@@ -60,15 +60,10 @@ def launch(connection, vessel, heading, target_altitude):
     vessel.auto_pilot.target_pitch = 0
     vessel.control.throttle = 0
     vessel.control.rcs = True
+    vessel.auto_pilot.disengage()
     time.sleep(1)
 
-    # Keep boosting until the periapsis reaches the target altitude
-    while vessel.orbit.periapsis_altitude < target_altitude:
-        if vessel.orbit.time_to_apoapsis < 30:
-            vessel.control.throttle = 1
-        else:
-            vessel.control.throttle = 0
-    print(f"At target periapsis: {vessel.orbit.periapsis_altitude}")
+    helpers.even_orbit(connection, vessel)
 
     # In stable orbit
     vessel.control.rcs = False


### PR DESCRIPTION
- Add mun.py, which takes a given vessel already in orbit around Kerbin and transfers it to the Mun
- New `even_orbit` helper function which gets the current apoapsis/periapsis (whichever is first) and evens out the other side of the orbit.
- Updated orbit.py to use this new helper function.
- Black formatting